### PR TITLE
Add support for auto-switching the default assistant app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 CTSLauncher is a shortcut and quick settings tile for launching the contextual search activity in the Google app. It is useful for Android OS's that do not have the system-level contextual search integration with the Google app.
 
-CTSLauncher does not require any permissions.
+CTSLauncher does not require any permissions by default.
 
 **NOTE**: The Google app determines whether Circle to Search or Google Assistant is launched (or even doing nothing), depending on the Android version and device model. CTSLauncher does **not** make Circle to Search work on devices where it is not supported.
 
@@ -18,6 +18,20 @@ CTSLauncher does not require any permissions.
 2. Make sure the Google app is set as the default assistant app in Android's Settings -> Apps -> Default apps -> Digital assistant app.
 
 3. That's it! When CTSLauncher is opened, either via the app icon or quick settings tile, it will trigger the Google app's contextual search feature.
+
+## Auto-switching assistant app
+
+If the system has a different default assistant app set, CTSLauncher can automatically switch the assistant app to the Google app, launch CTS, and then restore the setting. This requires granting the `WRITE_SECURE_SETTINGS` permission via `adb`:
+
+```bash
+adb shell pm grant com.chiller3.ctslauncher android.permission.WRITE_SECURE_SETTINGS
+```
+
+To revoke the permissions, run:
+
+```bash
+adb shell pm revoke com.chiller3.ctslauncher android.permission.WRITE_SECURE_SETTINGS
+```
 
 ## Verifying digital signatures
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,17 @@
 -->
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+        This is for automatically switching the assistant when launching CTS. This is completely
+        optional. It is not (and cannot be) used without explicitly granting the permission via adb.
+    -->
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
+
+    <queries>
+        <package android:name="com.google.android.googlequicksearchbox" />
+    </queries>
+
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -30,6 +41,10 @@
             android:exported="false"
             android:excludeFromRecents="true"
             android:theme="@style/Theme.CTSLauncher.Transparent" />
+
+        <service
+            android:name=".AssistantRestoreService"
+            android:exported="false" />
 
         <service
             android:name=".CtsTileService"

--- a/app/src/main/java/com/chiller3/ctslauncher/AssistantRestoreService.java
+++ b/app/src/main/java/com/chiller3/ctslauncher/AssistantRestoreService.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.ctslauncher;
+
+import android.app.Service;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+
+public class AssistantRestoreService extends Service {
+    private static final String EXTRA_COMPONENT = "component";
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final Runnable restoreAssistant = this::restoreAssistant;
+
+    private ComponentName origComponent;
+
+    public static Intent createIntent(Context context, ComponentName component) {
+        final var intent = new Intent(context, AssistantRestoreService.class);
+        intent.putExtra(EXTRA_COMPONENT, component);
+        return intent;
+    }
+
+    public static <T> T getParcelableExtra(Intent intent, String name, Class<T> clazz) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // This is broken on API 33.
+            return intent.getParcelableExtra(name, clazz);
+        } else {
+            //noinspection deprecation,unchecked
+            T extra = intent.getParcelableExtra(name);
+            return clazz.isInstance(extra) ? extra : null;
+        }
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        origComponent = getParcelableExtra(intent, EXTRA_COMPONENT, ComponentName.class);
+
+        handler.removeCallbacks(restoreAssistant);
+        handler.postDelayed(restoreAssistant, 1000);
+
+        return START_NOT_STICKY;
+    }
+
+    private void restoreAssistant() {
+        AssistantSwitcher.restoreAssistant(this, origComponent);
+        stopSelf();
+    }
+}

--- a/app/src/main/java/com/chiller3/ctslauncher/AssistantSwitcher.java
+++ b/app/src/main/java/com/chiller3/ctslauncher/AssistantSwitcher.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.ctslauncher;
+
+import android.Manifest;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.provider.Settings;
+import android.service.voice.VoiceInteractionService;
+import android.util.Log;
+
+public final class AssistantSwitcher {
+    private static final String TAG = AssistantSwitcher.class.getSimpleName();
+
+    // Google Assistant package name.
+    private static final String PACKAGE_NAME = "com.google.android.googlequicksearchbox";
+
+    // Settings.Secure.VOICE_INTERACTION_SERVICE
+    private static final String VOICE_INTERACTION_SERVICE = "voice_interaction_service";
+
+    private AssistantSwitcher() {}
+
+    private static ComponentName getAssistantComponent(Context context) {
+        final var rawComponent = Settings.Secure.getString(context.getContentResolver(),
+                VOICE_INTERACTION_SERVICE);
+        if (rawComponent == null || rawComponent.isEmpty()) {
+            return null;
+        }
+
+        return ComponentName.unflattenFromString(rawComponent);
+    }
+
+    private static void setAssistantComponent(Context context, ComponentName component) {
+        Settings.Secure.putString(context.getContentResolver(), VOICE_INTERACTION_SERVICE,
+                component != null ? component.flattenToString() : "");
+    }
+
+    private static ComponentName findCtsComponent(Context context) {
+        final var resolveInfos = context.getPackageManager().queryIntentServices(
+                new Intent(VoiceInteractionService.SERVICE_INTERFACE)
+                        .setPackage(PACKAGE_NAME),
+                PackageManager.GET_META_DATA
+                        | PackageManager.MATCH_DIRECT_BOOT_AWARE
+                        | PackageManager.MATCH_DIRECT_BOOT_UNAWARE);
+
+        for (final var resolveInfo : resolveInfos) {
+            final var serviceInfo = resolveInfo.serviceInfo;
+
+            if (!Manifest.permission.BIND_VOICE_INTERACTION.equals(serviceInfo.permission)) {
+                continue;
+            }
+
+            if (!serviceInfo.metaData.containsKey(VoiceInteractionService.SERVICE_META_DATA)) {
+                continue;
+            }
+
+            return new ComponentName(serviceInfo.packageName, serviceInfo.name);
+        }
+
+        return null;
+    }
+
+    public record SwitchResult(ComponentName component, boolean changed) {}
+
+    public static SwitchResult switchAssistant(Context context) {
+        final ComponentName origComponent = getAssistantComponent(context);
+        final ComponentName ctsComponent = findCtsComponent(context);
+
+        Log.i(TAG, "Original assistant: " + origComponent);
+        Log.i(TAG, "CTS assistant: " + ctsComponent);
+
+        if (ctsComponent == null) {
+            Log.w(TAG, "Not switching due to null CTS component");
+        } else if (ctsComponent.equals(origComponent)) {
+            Log.i(TAG, "Not switching because component already matches");
+        } else {
+            Log.i(TAG, "Switching from " + origComponent + " to " + ctsComponent);
+
+            try {
+                setAssistantComponent(context, ctsComponent);
+
+                // This is atrocious, but we have no way to synchronously determine when
+                // VoiceInteractionManagerService has reloaded itself after observing the settings
+                // change.
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    Log.w(TAG, "Interrupted delay", e);
+                }
+
+                return new SwitchResult(origComponent, true);
+            } catch (SecurityException e) {
+                Log.w(TAG, "Failed to switch to CTS assistant", e);
+            }
+        }
+
+        return new SwitchResult(null, false);
+    }
+
+    public static void restoreAssistant(Context context, ComponentName origComponent) {
+        Log.i(TAG, "Switching assistant back to " + origComponent);
+
+        try {
+            setAssistantComponent(context, origComponent);
+        } catch (SecurityException e) {
+            Log.e(TAG, "Failed to switch back to original assistant", e);
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/ctslauncher/CtsLauncher.java
+++ b/app/src/main/java/com/chiller3/ctslauncher/CtsLauncher.java
@@ -123,6 +123,8 @@ public final class CtsLauncher {
         //
         // [1] https://android.googlesource.com/platform/frameworks/base/+/b26321f6af2acb4d30730002e43d99a3e5c5a3e6%5E%21/
 
+        final var switchResult = AssistantSwitcher.switchAssistant(context);
+
         try {
             final var service = getService(VOICE_INTERACTION_MANAGER_SERVICE);
 
@@ -151,6 +153,11 @@ public final class CtsLauncher {
         } catch (Exception e) {
             Log.e(TAG, "Failed to launch CTS", e);
             Toast.makeText(context, e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
+        } finally {
+            if (switchResult.changed()) {
+                context.startService(AssistantRestoreService.createIntent(
+                        context, switchResult.component()));
+            }
         }
     }
 }


### PR DESCRIPTION
If the user manually grants the `WRITE_SECURE_SETTINGS` permission via adb, we'll try to switch the default assistant app to the Google app, launch CTS, and then restore the original setting.

The activity that `VoiceInteractionManagerService` launches is determined by the `voice_interaction_service` setting.

This is absolutely horrendously ugly:

- Changing the setting does not have an immediate effect. We have to block the main thread and sleep for 200ms to wait for `VoiceInteractionManagerService` to reload its configuration. This threshold is the smallest delay I found to consistently work on my Pixel Tablet. We can't use any proper delaying/scheduling mechanism because Android does not allow them to be used in invisible activities, which `CtsImmediateActivity` uses to prevent unwanted flickering and animations. Luckily, blocking the main thread for 200ms is short enough that Android won't show the "app not responding" dialog.

- After CTS is launched, the Google app actually communicates with `VoiceInteractionManagerService`. The setting cannot be immediately restored or else the service will reload its configuration while the Google app is using it, resulting in a `SecurityException`. The Google app does not handle this and will crash. We have no way to determine when CTS is finished with using the service and we have no way to determine when the user closes CTS. So we need to add yet another arbitrary delay before restoring the setting. This is currently 1000ms.

- We can't block the main thread to restore the setting like we do for the pre-launch delay. Calling `showSessionFromSession()` requires the main event loop to keep processing events before the service will launch the CTS activity. Blocking the main thread will cause the sleep to happen before CTS is actually launched. Instead, after launching CTS, we'll spawn a background service just to handle the delayed restoring of the setting.

Fixes: #4