### PR TITLE
Remove Google Play dependency info block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,6 +153,10 @@ android {
         sourceCompatibility(JavaVersion.VERSION_21)
         targetCompatibility(JavaVersion.VERSION_21)
     }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 val archive = tasks.register("archive") {


### PR DESCRIPTION
This metadata is encrypted with Google's public key and is unreadable by anyone else. We have no need for this.