### PR TITLE
CtsTileService: Increase delay to 600ms

### DIFF
--- a/app/src/main/java/com/chiller3/ctslauncher/CtsTileService.java
+++ b/app/src/main/java/com/chiller3/ctslauncher/CtsTileService.java
@@ -11,7 +11,7 @@ import android.os.Build;
 import android.service.quicksettings.TileService;
 
 public class CtsTileService extends TileService {
-    private static final long SYNC_DELAY_MS = 500L;
+    private static final long SYNC_DELAY_MS = 600L;
 
     @SuppressLint("StartActivityAndCollapseDeprecated")
     @Override


### PR DESCRIPTION
Android 16 QPR1 dismisses the visible UI elements in the notification panel as quickly as older versions, but takes longer to remove the whole-screen blur effect.