### PR TITLE
Register the app as an assistant

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,10 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                 <action android:name="android.intent.action.ASSIST" />
+                 <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
added an `intent-filter` in the manifest to register the main activity as an assistant app

seems to work quite well in combination with the extra `adb shell`-issued permissions to overwrite the system assistant app, allowing quickly opening cts from anywhere